### PR TITLE
Adding package versions to the refusal_mi.ipynb file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Refusal in LLMs. refusal_mi
+# Readme for refusal in LLMs. refusal_mi
 
-## Notes from xretr0
+## Notes from xretr0, Anton Szorkin
 
 I have added the versions of the dependencies.
 
@@ -10,10 +10,7 @@ I have added the versions of the dependencies.
 - plotly==5.17.0 
 - circuitsvis==1.41.0 
 - numpy==1.25.2 
-- transformers==4.34.1 
+- transformers==4.37.2 
 - sentencepiece==0.1.99 
 - scikit-learn==1.3.1 
 - jaxtyping==0.2.25
-
-At the moment, the transformers==4.34.1 library has a vulnerability as 
-far as I am aware.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Refusal in LLMs. refusal_mi
+
+## Notes from xretr0
+
+I have added the versions of the dependencies.
+
+- torch==2.1.0 
+- einops==0.7.0 
+- transformer_lens==1.7.0 
+- plotly==5.17.0 
+- circuitsvis==1.41.0 
+- numpy==1.25.2 
+- transformers==4.34.1 
+- sentencepiece==0.1.99 
+- scikit-learn==1.3.1 
+- jaxtyping==0.2.25
+
+At the moment, the transformers==4.34.1 library has a vulnerability as 
+far as I am aware.


### PR DESCRIPTION
Hi!

I found your project interesting, and while replicating it, I stumbled into some version conflicts. 

I resolved the issue with the versions and thought of adding this change for future use.

The versions were taken as the most recent as of October 19th, 2023, the first commit date. The only exception is the transformers library, which had some vulnerabilities in this version.

I've also added the readme file to the root directory with the note about the versions.

All the code seems to be running well, and all the generated images are the same as in your report. 

I hope you will find it helpful.
Best regards,
Anton Szorkin.